### PR TITLE
pipeline-stream: Add another way to find dai in case of failure

### DIFF
--- a/src/audio/pipeline/pipeline-stream.c
+++ b/src/audio/pipeline/pipeline-stream.c
@@ -502,8 +502,16 @@ void pipeline_get_timestamp(struct pipeline *p, struct comp_dev *host,
 	data.posn = posn;
 
 	if (walk_ctx.comp_func(host, NULL, &walk_ctx, host->direction) !=
-	    PPL_STATUS_PATH_STOP)
-		pipe_dbg(p, "pipeline_get_timestamp(): DAI position update failed");
+	    PPL_STATUS_PATH_STOP) {
+		struct comp_dev *dai = pipeline_get_dai_comp(host->pipeline->pipeline_id);
+
+		if (!dai) {
+			pipe_dbg(p, "pipeline_get_timestamp(): DAI position update failed");
+			return;
+		}
+
+		platform_dai_timestamp(dai, posn);
+	}
 
 	/* set timestamp resolution */
 	posn->timestamp_ns = p->period * 1000;


### PR DESCRIPTION
At the moment, pipeline_get_timestamp is called by host_dma_cb.
This is bad because pipeline_get_timestamp will not be able
to reach the DAI in order to query it for the dai_posn
because it will always be called during a graph walkthrough
done by the copy operation. This change will allow
pipeline_get_timestamp to work on platforms on which the
host copy operation automatically calls
pipeline_get_timestamp.

Signed-off-by: Laurentiu Mihalcea <laurentiu.mihalcea@nxp.com>